### PR TITLE
Addressed an issue casued by NSRangeException : Range or index out of bo...

### DIFF
--- a/src/orm/ZIMOrmModel.m
+++ b/src/orm/ZIMOrmModel.m
@@ -314,7 +314,7 @@
 		NSString *columnName = [NSString stringWithUTF8String: ivar_getName(var)];
 		if (![configurations containsObject: columnName]) {
 			if ([columnName hasPrefix: @"_"]) {
-				columnName = [columnName substringWithRange: NSMakeRange(1, [columnName length])];
+				columnName = [columnName substringFromIndex: 1];
 			}
 			NSString *columnType = [NSString stringWithUTF8String: ivar_getTypeEncoding(var)]; // http://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
 			[columns setObject: columnType forKey: columnName];

--- a/src/sql/ZIMSqlCreateTableStatement.m
+++ b/src/sql/ZIMSqlCreateTableStatement.m
@@ -149,7 +149,7 @@
 		[sql appendString: @" TEMPORARY"];
 	}
 	
-	[sql appendFormat: @" TABLE %@ (", _table];
+	[sql appendFormat: @" TABLE IF NOT EXISTS %@ (", _table];
 
 	int i = 0;
 	for (NSString *column in _columnArray) {


### PR DESCRIPTION
...unds in the columns method of ZIMOrmModel
### Changes:
- A very small change to how the `columns` method of `ZIMOrmModel` was creating an `NSRange` for use in `substringWithRange:`. Converted `substringWithRange:` to `substringFromRange:` which will substring from the index given to the end of the string.

This fix resolves this issue: https://github.com/ziminji/objective-c-sql-query-builder/issues/20
