### PR TITLE
Added IF NOT EXISTS to the table creation statement to avoid throwing an...

### DIFF
--- a/src/sql/ZIMSqlCreateTableStatement.m
+++ b/src/sql/ZIMSqlCreateTableStatement.m
@@ -149,7 +149,7 @@
 		[sql appendString: @" TEMPORARY"];
 	}
 	
-	[sql appendFormat: @" TABLE %@ (", _table];
+	[sql appendFormat: @" TABLE IF NOT EXISTS %@ (", _table];
 
 	int i = 0;
 	for (NSString *column in _columnArray) {


### PR DESCRIPTION
... exception if a table already exists
### Changes:
- Added `IF NOT EXISTS` to the db table creation `statement` builder method of `ZIMSqlCreateTableStatement`.
- This allows for a much more gracefully table creation as it will not throw an exception if the table already exists.
